### PR TITLE
fix(payment): use transactionAmount instead of totalPaidAmount

### DIFF
--- a/src/main/java/um/tesoreria/mercadopago/service/service/PaymentService.java
+++ b/src/main/java/um/tesoreria/mercadopago/service/service/PaymentService.java
@@ -286,7 +286,7 @@ public class PaymentService {
         } catch (JsonProcessingException e) {
             log.error("PaymentString Error -> {}", e.getMessage());
         }
-        context.setImportePagado(payment.getTransactionDetails().getTotalPaidAmount());
+        context.setImportePagado(payment.getTransactionAmount());
         context.setFechaPago(payment.getDateApproved());
         context.setFechaAcreditacion(payment.getMoneyReleaseDate());
         context.setStatus(payment.getStatus());


### PR DESCRIPTION
The payment amount was being taken from totalPaidAmount which is an internal MercadoPago field. Changed to use transactionAmount which represents the actual transaction amount.

BREAKING CHANGE: Payment amount calculation changed from totalPaidAmount to transactionAmount