### PR TITLE
chore(deps): update Spring Boot to 3.4.2 and OpenAPI to 2.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.1</version>
+		<version>3.4.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>um.tesoreria</groupId>
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.7.0</version>
+			<version>2.8.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Update project dependencies to their latest stable versions:
- Spring Boot from 3.4.1 to 3.4.2
- SpringDoc OpenAPI UI from 2.7.0 to 2.8.4

These updates include security patches and performance improvements. All tests have been executed and functionality remains stable.

Closes #22