### PR TITLE
ci(workflow): build manual de Jekyll para soportar temas personalizad…

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -72,10 +72,11 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
         
-      - name: Build with Jekyll
+      - name: Build Jekyll site
         run: |
           cd docs
-          bundle exec jekyll build --baseurl "${{ steps.deployment.outputs.base_path }}"
+          bundle install
+          bundle exec jekyll build
         env:
           JEKYLL_ENV: production
       


### PR DESCRIPTION
…os en GitHub Pages\n\n- Elimina el uso de actions/jekyll-build-pages@v1\n- Agrega pasos para instalar dependencias Ruby y construir el sitio Jekyll manualmente\n- Sube docs/_site como artifact para Pages\n\nRefs: #68