### PR TITLE
feat(release): Release version 0.1.2

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 
-name: UM.tesoeria.mercadopago-service Build JVM Image
+name: UM.tesoreria.mercadopago-service Build JVM Image
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [0.1.2] - 2025-08-16
+
+### Added
+- feat(domain): añade campo `lastVencimientoUpdated` en `MercadoPagoContextDto` para rastrear última actualización de vencimiento (fuente: `src/.../domain/dto/MercadoPagoContextDto.java`, `git diff HEAD`)
+- feat(service): actualiza `lastVencimientoUpdated` al modificar preferencias en `PreferenceService` (fuente: `src/.../service/PreferenceService.java`, `git diff HEAD`)
+
+### Fixed
+- fix(workflow): corrige typo en nombre del workflow de GitHub Actions (fuente: `.github/workflows/maven.yml`, `git diff HEAD`)
+
 ## [0.1.1] - 2025-08-14
 
 ### Changed
@@ -49,4 +58,4 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 #### Fuente de la información:
 - Los cambios y fechas provienen del análisis del código (`git diff HEAD`) y del historial (`git log`).
 - Las versiones de dependencias provienen del archivo `pom.xml`.
-- La versión actual del proyecto propuesta para release es 0.1.1.
+- La versión actual del proyecto es 0.1.2.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Servicio de integración con MercadoPago para la gestión de pagos y preferencia
 
 ## Versión del Proyecto
 
-- **Versión actual:** 0.1.1 _(fuente: pom.xml)_
+- **Versión actual:** 0.1.2 _(fuente: pom.xml)_
 
 ## Características Principales
 
@@ -14,6 +14,7 @@ Servicio de integración con MercadoPago para la gestión de pagos y preferencia
 - Manejo robusto de errores y logging detallado
 - Integración con sistema de chequeras
 - Soporte para copias de email en notificaciones
+- Registro de última actualización de vencimiento de preferencias
 
 ## Requisitos
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>um.tesoreria</groupId>
 	<artifactId>mercadopago-service</artifactId>
-	<version>0.1.1</version>
+	<version>0.1.2</version>
 	<name>UM.tesoreria.mercadopago-service</name>
 	<description>um.tesoreria.mercadopago-service</description>
 	<url/>

--- a/src/main/java/um/tesoreria/mercadopago/service/domain/dto/MercadoPagoContextDto.java
+++ b/src/main/java/um/tesoreria/mercadopago/service/domain/dto/MercadoPagoContextDto.java
@@ -27,6 +27,10 @@ public class MercadoPagoContextDto {
 
     private BigDecimal importe = BigDecimal.ZERO;
     private Byte changed = 0;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    private OffsetDateTime lastVencimientoUpdated;
+
     private String preferenceId;
     private String preference;
     private Byte activo = 0;

--- a/src/main/java/um/tesoreria/mercadopago/service/service/PreferenceService.java
+++ b/src/main/java/um/tesoreria/mercadopago/service/service/PreferenceService.java
@@ -1,7 +1,5 @@
 package um.tesoreria.mercadopago.service.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.mercadopago.client.preference.*;
 import com.mercadopago.exceptions.MPApiException;
 import com.mercadopago.exceptions.MPException;
@@ -19,6 +17,8 @@ import um.tesoreria.mercadopago.service.domain.dto.UMPreferenceMPDto;
 import um.tesoreria.mercadopago.service.serializer.JacksonJsonSerializer;
 import um.tesoreria.mercadopago.service.util.DateToolMP;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -125,6 +125,7 @@ public class PreferenceService {
             log.debug("Preferencia actualizada con éxito");
             mercadoPagoContext.setChanged((byte) 0);
             mercadoPagoContext.setPreference(new JacksonJsonSerializer().jsonify(preference));
+            mercadoPagoContext.setLastVencimientoUpdated(OffsetDateTime.now(ZoneOffset.UTC));
             mercadoPagoContext = mercadoPagoCoreClient.updateContext(mercadoPagoContext, mercadoPagoContext.getMercadoPagoContextId());
         } catch (MPException | MPApiException e) {
             log.debug("Error al actualizar la preferencia: {}", e.getMessage());


### PR DESCRIPTION
## Descripción
Este Pull Request prepara el repositorio para el lanzamiento de la **versión `0.1.2`**. Incluye una nueva funcionalidad para el seguimiento de vencimientos, una corrección menor en el pipeline de CI/CD y la actualización de la documentación correspondiente.

Este PR cierra el issue #79.

## Cambios Realizados
- [x] **Feature**: Se añade el campo `lastVencimientoUpdated` a `MercadoPagoContextDto` para registrar la fecha de la última actualización del vencimiento.
- [x] **Fix**: Se corrige un error tipográfico en el nombre del workflow de GitHub Actions (`.github/workflows/maven.yml`).
- [x] **Docs**: Se actualizan `README.md` y `CHANGELOG.md` para reflejar la nueva versión y sus cambios.
- [x] **Chore**: Se incrementa la versión del proyecto a `0.1.2` en el archivo `pom.xml`.

## Impacto Potencial
- [ ] No se esperan impactos negativos ni cambios que rompan la compatibilidad. La nueva funcionalidad es aditiva y las demás modificaciones son correctivas o de documentación.
- [ ] No se requieren cambios en variables de entorno ni migraciones de base de datos.

## Verificación
Para verificar los cambios:
1.  Ejecutar `git checkout 79-feat-preparación-para-el-lanzamiento-de-la-versión-012`.
2.  Construir el proyecto con `mvn clean install`.
3.  Verificar que la compilación sea exitosa y que las pruebas pasen.
4.  Revisar el archivo `pom.xml` para confirmar que la versión es `0.1.2`.

## Notas Adicionales
Este PR agrupa un conjunto de cambios relacionados con el lanzamiento de la versión para mantener la atomicidad del release.
