### PR TITLE
chore: actualizar dependencias para la versión 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,17 +80,17 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 
 - **Antiguo sistema de documentación:** Se ha eliminado el antiguo sistema de documentación basado en Jekyll.
 
-## [Unreleased]
+## [0.4.0] - 2026-02-03
 
-### Versiones de dependencias principales (fuente: pom.xml)
-
-- Spring Boot: 3.5.6
-- Spring Cloud: 2025.0.0
-- Java: 25
-- MercadoPago SDK: 2.5.0
-- SpringDoc OpenAPI: 2.8.10
+### Changed
+- chore(deps): Actualización de Spring Boot de 3.5.8 a 4.0.2 (fuente: `pom.xml`, `git diff HEAD`)
+- chore(deps): Actualización de Spring Cloud de 2025.0.0 a 2025.1.0 (fuente: `pom.xml`, `git diff HEAD`)
+- chore(deps): Actualización de MercadoPago SDK de 2.5.0 a 2.8.0 (fuente: `pom.xml`, `git diff HEAD`)
+- chore(deps): Actualización de SpringDoc OpenAPI de 2.8.10 a 3.0.1 (fuente: `pom.xml`, `git diff HEAD`)
+- chore(deps): Actualización de commons-fileupload de 1.5 a 1.6.0 (fuente: `pom.xml`, `git diff HEAD`)
+- chore(deps): Actualización de commons-beanutils de 1.9.4 a 1.11.0 (fuente: `pom.xml`, `git diff HEAD`)
+- chore(deps): Actualización de commons-lang3 de 3.18.0 a 3.20.0 (fuente: `pom.xml`, `git diff HEAD`)
 
 #### Fuente de la información:
 - Los cambios y fechas provienen del análisis del código (`git diff HEAD`) y del historial (`git log`).
 - Las versiones de dependencias provienen del archivo `pom.xml`.
-- La versión actual del proyecto es 0.2.0.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Servicio de integración con MercadoPago para la gestión de pagos y preferencia
 
 ## Versión del Proyecto
 
-- **Versión actual:** 0.3.1 _(fuente: pom.xml)_
+- **Versión actual:** 0.4.0 _(fuente: pom.xml)_
 
 ## Características Principales
 
@@ -21,10 +21,10 @@ Servicio de integración con MercadoPago para la gestión de pagos y preferencia
 ## Requisitos
 
 - Java 25 _(fuente: pom.xml)_
-- Spring Boot 3.5.6 _(fuente: pom.xml)_
-- Spring Cloud 2025.0.0 _(fuente: pom.xml)_
-- MercadoPago SDK 2.5.0 _(fuente: pom.xml)_
-- Springdoc OpenAPI 2.8.10 _(fuente: pom.xml)_
+- Spring Boot 4.0.2 _(fuente: pom.xml)_
+- Spring Cloud 2025.1.0 _(fuente: pom.xml)_
+- MercadoPago SDK 2.8.0 _(fuente: pom.xml)_
+- Springdoc OpenAPI 3.0.1 _(fuente: pom.xml)_
 - Base de datos PostgreSQL
 
 ## Configuración
@@ -94,10 +94,10 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE](LICENSE) par
 [![Generate Documentation](https://github.com/UM-services/UM.tesoreria.mercadopago-service/actions/workflows/generate-docs.yml/badge.svg)](https://github.com/UM-services/UM.tesoreria.mercadopago-service/actions/workflows/generate-docs.yml)
 
 [![Java](https://img.shields.io/badge/Java-25-red?logo=java)](https://www.java.com)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-brightgreen?logo=spring)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue?logo=spring)](https://spring.io/projects/spring-cloud)
-[![MercadoPago](https://img.shields.io/badge/MercadoPago%20SDK-2.5.0-lightblue?logo=mercadopago)](https://www.mercadopago.com.ar/developers/es)
-[![OpenAPI](https://img.shields.io/badge/OpenAPI-2.8.10-green?logo=openapi-initiative)](https://www.openapis.org/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen?logo=spring)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue?logo=spring)](https://spring.io/projects/spring-cloud)
+[![MercadoPago](https://img.shields.io/badge/MercadoPago%20SDK-2.8.0-lightblue?logo=mercadopago)](https://www.mercadopago.com.ar/developers/es)
+[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.1-green?logo=openapi-initiative)](https://www.openapis.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9+-purple?logo=apache-maven)](https://maven.apache.org/)
 
 ## Autor ✍️
@@ -127,11 +127,11 @@ El estado actual del proyecto, incluyendo issues activos y milestones, se puede 
 ## Tecnologías
 
 - Java 25 _(fuente: pom.xml)_
-- Spring Boot 3.5.6 _(fuente: pom.xml)_
-- Spring Cloud 2025.0.0 _(fuente: pom.xml)_
-- MercadoPago SDK Java 2.5.0 _(fuente: pom.xml)_
+- Spring Boot 4.0.2 _(fuente: pom.xml)_
+- Spring Cloud 2025.1.0 _(fuente: pom.xml)_
+- MercadoPago SDK Java 2.8.0 _(fuente: pom.xml)_
 - Caffeine (para caché)
-- Springdoc OpenAPI 2.8.10 _(fuente: pom.xml)_
+- Springdoc OpenAPI 3.0.1 _(fuente: pom.xml)_
 
 ## Endpoints
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.8</version>
+		<version>4.0.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>um.tesoreria</groupId>
 	<artifactId>mercadopago-service</artifactId>
-	<version>0.3.1</version>
+	<version>0.4.0</version>
 	<name>UM.tesoreria.mercadopago-service</name>
 	<description>um.tesoreria.mercadopago-service</description>
 	<url/>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-cloud.version>2025.0.0</spring-cloud.version>
+		<spring-cloud.version>2025.1.0</spring-cloud.version>
 		<sonar.organization>um-services</sonar.organization>
 		<sonar.projectKey>UM-services_UM.tesoreria.mercadopago-service</sonar.projectKey>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -66,12 +66,12 @@
 		<dependency>
 			<groupId>com.mercadopago</groupId>
 			<artifactId>sdk-java</artifactId>
-			<version>2.5.0</version>
+			<version>2.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.8.10</version>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -110,17 +110,17 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.5</version>
+                <version>1.6.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version>
+                <version>1.11.0</version>
             </dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.18.0</version>
+				<version>3.20.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.iq80.snappy</groupId>


### PR DESCRIPTION
Closes #93

## Descripción

Actualización de dependencias para la versión 0.4.0 del servicio de integración con MercadoPago. El objetivo es mantener la seguridad y compatibilidad del sistema al actualizar a versiones más recientes de las dependencias principales.

## Cambios Realizados

- Actualización de Spring Boot de 3.5.8 a 4.0.2
- Actualización de Spring Cloud de 2025.0.0 a 2025.1.0
- Actualización de MercadoPago SDK de 2.5.0 a 2.8.0
- Actualización de SpringDoc OpenAPI de 2.8.10 a 3.0.1
- Actualización de commons-fileupload de 1.5 a 1.6.0
- Actualización de commons-beanutils de 1.9.4 a 1.11.0
- Actualización de commons-lang3 de 3.18.0 a 3.20.0
- Aumento de la versión del proyecto de 0.3.1 a 0.4.0
- Actualización de la documentación en CHANGELOG.md y README.md

## Verificación

- Los cambios han sido compilados y probados localmente
- Las dependencias se resolvieron correctamente
- La documentación ha sido actualizada con la información de la versión 0.4.0
