### PR TITLE
chore(release): bump to v0.6.1 - deps & docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [0.6.1] - 2026-06-15
+
+### Changed
+- chore(deps): Actualización de MercadoPago SDK de 2.8.0 a 3.2.1 (fuente: `pom.xml`, `git diff HEAD`)
+- chore(deps): Actualización de SpringDoc OpenAPI de 3.0.2 a 3.0.3 (fuente: `pom.xml`, `git diff HEAD`)
+- chore(deps): Actualización de plexus-utils de 4.0.2 a 4.0.3 (fuente: `pom.xml`, `git diff HEAD`)
+
 ## [0.6.0] - 2026-06-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Servicio de integración con MercadoPago para la gestión de pagos y preferencia
 
 ## Versión del Proyecto
 
-- **Versión actual:** 0.6.0 _(fuente: pom.xml)_
+- **Versión actual:** 0.6.1 _(fuente: pom.xml)_
 
 ## Características Principales
 
@@ -23,9 +23,8 @@ Servicio de integración con MercadoPago para la gestión de pagos y preferencia
 - Java 25 _(fuente: pom.xml)_
 - Spring Boot 4.1.0 _(fuente: pom.xml)_
 - Spring Cloud 2025.1.2 _(fuente: pom.xml)_
-- MercadoPago SDK 2.8.0 _(fuente: pom.xml)_
-- Springdoc OpenAPI 3.0.2 _(fuente: pom.xml)_
-- Base de datos PostgreSQL
+- MercadoPago SDK 3.2.1 _(fuente: pom.xml)_
+- Springdoc OpenAPI 3.0.3 _(fuente: pom.xml)_
 
 ## Configuración
 
@@ -49,24 +48,15 @@ CHEQUERA_SERVICE_URL=http://localhost:8080
 
 ## Uso
 
-El servicio expone endpoints REST para la gestión de preferencias de pago:
+El servicio expone endpoints REST para la gestión de preferencias de pago y pagos:
 
-- `POST /api/v1/preferences`: Crear una nueva preferencia
-- `PUT /api/v1/preferences/{id}`: Actualizar una preferencia existente
-- `GET /api/v1/preferences/{id}`: Obtener una preferencia específica
-
-### Ejemplo de Uso
-
-```java
-// Crear una preferencia
-PreferenceRequest request = PreferenceRequest.builder()
-    .items(List.of(item))
-    .payer(payer)
-    .paymentMethods(paymentMethods)
-    .build();
-
-Preference preference = preferenceService.createPreference(request);
-```
+- `POST /api/tesoreria/mercadopago/preference/create`: Crear una nueva preferencia de pago
+- `GET /api/tesoreria/mercadopago/preference/retrieve/{preferenceId}`: Obtener una preferencia específica
+- `POST /api/tesoreria/mercadopago/payment/listener`: Webhook de notificaciones de pago (IPN)
+- `GET /api/tesoreria/mercadopago/payment/update/{dataId}`: Forzar actualización de un pago
+- `GET /api/tesoreria/mercadopago/chequera/create/context/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{alternativaId}`: Crear preferencias para cuotas pendientes
+- `GET /api/tesoreria/mercadopago/checking/cuota/{chequeraCuotaId}`: Verificar/renovar cuota individual
+- `GET /api/tesoreria/mercadopago/checking/all/active`: Verificar todas las preferencias activas
 
 ## Logging
 
@@ -96,8 +86,8 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE](LICENSE) par
 [![Java](https://img.shields.io/badge/Java-25-red?logo=java)](https://www.java.com)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen?logo=spring)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-blue?logo=spring)](https://spring.io/projects/spring-cloud)
-[![MercadoPago](https://img.shields.io/badge/MercadoPago%20SDK-2.8.0-lightblue?logo=mercadopago)](https://www.mercadopago.com.ar/developers/es)
-[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.2-green?logo=openapi-initiative)](https://www.openapis.org/)
+[![MercadoPago](https://img.shields.io/badge/MercadoPago%20SDK-3.2.1-lightblue?logo=mercadopago)](https://www.mercadopago.com.ar/developers/es)
+[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-green?logo=openapi-initiative)](https://www.openapis.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9+-purple?logo=apache-maven)](https://maven.apache.org/)
 
 ## Autor ✍️
@@ -129,9 +119,9 @@ El estado actual del proyecto, incluyendo issues activos y milestones, se puede 
 - Java 25 _(fuente: pom.xml)_
 - Spring Boot 4.1.0 _(fuente: pom.xml)_
 - Spring Cloud 2025.1.2 _(fuente: pom.xml)_
-- MercadoPago SDK Java 2.8.0 _(fuente: pom.xml)_
+- MercadoPago SDK Java 3.2.1 _(fuente: pom.xml)_
 - Caffeine (para caché)
-- Springdoc OpenAPI 3.0.2 _(fuente: pom.xml)_
+- Springdoc OpenAPI 3.0.3 _(fuente: pom.xml)_
 
 ## Endpoints
 

--- a/docs/diagrams/flujo-creacion-preferencia.mmd
+++ b/docs/diagrams/flujo-creacion-preferencia.mmd
@@ -9,7 +9,7 @@ sequenceDiagram
     participant MP_API as "API de Mercado Pago"
 
     Usuario->>Frontend: 1. Selecciona chequera a pagar
-    Frontend->>PreferenceController: 2. POST /api/v1/preferences (UMPreferenceMPDto)
+    Frontend->>PreferenceController: 2. POST /api/tesoreria/mercadopago/preference/create (UMPreferenceMPDto)
     PreferenceController->>PreferenceService: 3. createPreference(dto)
     
     PreferenceService->>ChequeraService: 4. getChequera(chequeraId)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>um.tesoreria</groupId>
 	<artifactId>mercadopago-service</artifactId>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<name>UM.tesoreria.mercadopago-service</name>
 	<description>um.tesoreria.mercadopago-service</description>
 	<url/>
@@ -66,12 +66,12 @@
 		<dependency>
 			<groupId>com.mercadopago</groupId>
 			<artifactId>sdk-java</artifactId>
-			<version>2.8.0</version>
+			<version>3.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -142,7 +142,7 @@
 			<dependency>
 				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-utils</artifactId>
-				<version>4.0.2</version>
+				<version>4.0.3</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Closes #107

## Descripción
Release **v0.6.1** con actualización de dependencias y documentación.

## Cambios Realizados
- **chore(deps):** MercadoPago SDK Java `2.8.0` → `3.2.1`
- **chore(deps):** SpringDoc OpenAPI `3.0.2` → `3.0.3`
- **chore(deps):** plexus-utils `4.0.2` → `4.0.3`
- **docs(CHANGELOG):** Nueva sección v0.6.1 con cambios documentados
- **docs(README):** Versión, dependencias y endpoints actualizados
- **docs(diagrams):** Endpoint corregido en diagrama de secuencia Mermaid

## Verificación
- [ ] `mvn clean compile` exitoso
- [ ] Revisar compatibilidad con MercadoPago SDK 3.2.1
- [ ] Validar that los endpoints nuevos responden correctamente
