### PR TITLE
fix(preference): correct external reference for cuotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [0.7.1] - 2026-06-16
+
+### Fixed
+- fix(service): Corregido `createExternalReference` en `PreferenceService` para usar `chequeraCuotaId` en el flujo de cuotas y `reservaVacanteId` en el flujo de vacantes (fuente: `src/main/java/um/tesoreria/mercadopago/hexagonal/preference/service/PreferenceService.java:124-132`, `git diff HEAD`)
+
 ## [0.7.0] - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Servicio de integración con MercadoPago para la gestión de pagos y preferencia
 
 ## Versión del Proyecto
 
-- **Versión actual:** 0.7.0 _(fuente: pom.xml)_
+- **Versión actual:** 0.7.1 _(fuente: pom.xml)_
 
 ## Características Principales
 
@@ -92,7 +92,7 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE](LICENSE) par
 [![Generate Documentation](https://github.com/UM-services/UM.tesoreria.mercadopago-service/actions/workflows/generate-docs.yml/badge.svg)](https://github.com/UM-services/UM.tesoreria.mercadopago-service/actions/workflows/generate-docs.yml)
 
 [![Java](https://img.shields.io/badge/Java-25-red?logo=java)](https://www.java.com)
-[![Version](https://img.shields.io/badge/Version-0.7.0-orange)](https://github.com/UM-services/UM.tesoreria.mercadopago-service)
+[![Version](https://img.shields.io/badge/Version-0.7.1-orange)](https://github.com/UM-services/UM.tesoreria.mercadopago-service)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen?logo=spring)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-blue?logo=spring)](https://spring.io/projects/spring-cloud)
 [![MercadoPago](https://img.shields.io/badge/MercadoPago%20SDK-3.2.1-lightblue?logo=mercadopago)](https://www.mercadopago.com.ar/developers/es)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>um.tesoreria</groupId>
 	<artifactId>mercadopago-service</artifactId>
-	<version>0.7.0</version>
+	<version>0.7.1</version>
 	<name>UM.tesoreria.mercadopago-service</name>
 	<description>um.tesoreria.mercadopago-service</description>
 	<url/>

--- a/src/main/java/um/tesoreria/mercadopago/hexagonal/preference/service/PreferenceService.java
+++ b/src/main/java/um/tesoreria/mercadopago/hexagonal/preference/service/PreferenceService.java
@@ -123,7 +123,11 @@ public class PreferenceService {
 
     private String createExternalReference(UMPreferenceMPDto umPreferenceMPDto) {
         log.debug("\n\nProcessing PreferenceService.createExternalReference\n\n");
-        return String.format(umPreferenceMPDto.getReservaVacante().getReservaVacanteId()
+        if (umPreferenceMPDto.getChequeraCuota() == null) {
+            return String.format(umPreferenceMPDto.getReservaVacante().getReservaVacanteId()
+                    + "-" + umPreferenceMPDto.getMercadoPagoContext().getMercadoPagoContextId());
+        }
+        return String.format(umPreferenceMPDto.getChequeraCuota().getChequeraCuotaId()
                 + "-" + umPreferenceMPDto.getMercadoPagoContext().getMercadoPagoContextId());
     }
 


### PR DESCRIPTION
Closes #111

## Descripción

Se corrige el método `createExternalReference` en `PreferenceService` para manejar correctamente el flujo de cuotas (usando `chequeraCuotaId`) y el flujo de vacantes (usando `reservaVacanteId` como fallback). Adicionalmente se actualiza la versión del proyecto a 0.7.1.

## Cambios Realizados

- [x] Corregido `createExternalReference` en `PreferenceService.java` para diferenciar flujo de cuotas vs. vacantes
- [x] Version bump: `pom.xml` actualizado de `0.7.0` → `0.7.1`
- [x] `README.md`: badge de versión y texto actualizados
- [x] `CHANGELOG.md`: registro de cambios para v0.7.1 agregado

## Verificación

- Compilación exitosa con `mvn clean compile`
- Pruebas de integración del flujo de cuotas
- Pruebas de regresión del flujo de vacantes
