### PR TITLE
feat(preference): add sinRestricciones parameter for unrestricted payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [0.8.0] - 2026-06-19
+
+### Added
+- feat(preference): Nuevo parámetro `sinRestricciones` en `PreferenceService.buildPreferenceRequest()` y `createPaymentMethodsRequest()`. Cuando es `true`, genera preferencias sin exclusiones de medios de pago (sin límite de cuotas, sin excluir ticket/prepaid_card) (fuente: `src/main/java/um/tesoreria/mercadopago/hexagonal/preference/service/PreferenceService.java`, `git diff HEAD`)
+- feat(vacante): `PreferenceVacanteService` ahora crea preferencias sin restricciones de medios de pago (`sinRestricciones=true`) para el flujo de reserva de vacantes (fuente: `src/main/java/um/tesoreria/mercadopago/hexagonal/preference/vacante/application/service/PreferenceVacanteService.java`, `git diff HEAD`)
+
+### Changed
+- refactor(cuota): `PreferenceCuotaService` actualizado para usar `sinRestricciones=false`, preservando el comportamiento existente con exclusiones de medios de pago (fuente: `src/main/java/um/tesoreria/mercadopago/hexagonal/preference/cuota/application/service/PreferenceCuotaService.java`, `git diff HEAD`)
+
 ## [0.7.1] - 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Servicio de integración con MercadoPago para la gestión de pagos y preferencia
 
 ## Versión del Proyecto
 
-- **Versión actual:** 0.7.1 _(fuente: pom.xml)_
+- **Versión actual:** 0.8.0 _(fuente: pom.xml)_
 
 ## Características Principales
 
@@ -92,7 +92,7 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE](LICENSE) par
 [![Generate Documentation](https://github.com/UM-services/UM.tesoreria.mercadopago-service/actions/workflows/generate-docs.yml/badge.svg)](https://github.com/UM-services/UM.tesoreria.mercadopago-service/actions/workflows/generate-docs.yml)
 
 [![Java](https://img.shields.io/badge/Java-25-red?logo=java)](https://www.java.com)
-[![Version](https://img.shields.io/badge/Version-0.7.1-orange)](https://github.com/UM-services/UM.tesoreria.mercadopago-service)
+[![Version](https://img.shields.io/badge/Version-0.8.0-orange)](https://github.com/UM-services/UM.tesoreria.mercadopago-service)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen?logo=spring)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-blue?logo=spring)](https://spring.io/projects/spring-cloud)
 [![MercadoPago](https://img.shields.io/badge/MercadoPago%20SDK-3.2.1-lightblue?logo=mercadopago)](https://www.mercadopago.com.ar/developers/es)

--- a/docs/diagrams/flujo-creacion-preferencia.mmd
+++ b/docs/diagrams/flujo-creacion-preferencia.mmd
@@ -12,7 +12,7 @@ sequenceDiagram
     Frontend->>CuotaController: 2. POST /api/tesoreria/mercadopago/preference/create
     CuotaController->>CuotaService: 3. createPreference(dto)
     
-    CuotaService->>PrefService: 4. buildPreferenceRequest(dto, tipoChequeraContext)
+    CuotaService->>PrefService: 4. buildPreferenceRequest(dto, tipoChequeraContext, false)  // con restricciones
     PrefService->>PrefService: 5. Crea item, payer, paymentMethods
     PrefService-->>CuotaService: 6. PreferenceRequest
     

--- a/docs/diagrams/flujo-creacion-vacante.mmd
+++ b/docs/diagrams/flujo-creacion-vacante.mmd
@@ -16,8 +16,8 @@ sequenceDiagram
         VacanteService-->>VacanteController: 4. Retorna contexto existente
     else Nueva preferencia
         VacanteService->>PrefService: 4. setAccessTokenAndLog()
-        VacanteService->>PrefService: 5. buildPreferenceRequest(dto, null)
-        PrefService->>PrefService: 6. Crea item (vacante), payer, paymentMethods
+        VacanteService->>PrefService: 5. buildPreferenceRequest(dto, null, true)  // sin restricciones
+        PrefService->>PrefService: 6. Crea item (vacante), payer, paymentMethods (sin restricciones)
         PrefService-->>VacanteService: 7. PreferenceRequest
         
         VacanteService->>PrefService: 8. createAndLogPreference(request, context)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>um.tesoreria</groupId>
 	<artifactId>mercadopago-service</artifactId>
-	<version>0.7.1</version>
+	<version>0.8.0</version>
 	<name>UM.tesoreria.mercadopago-service</name>
 	<description>um.tesoreria.mercadopago-service</description>
 	<url/>

--- a/src/main/java/um/tesoreria/mercadopago/hexagonal/preference/cuota/application/service/PreferenceCuotaService.java
+++ b/src/main/java/um/tesoreria/mercadopago/hexagonal/preference/cuota/application/service/PreferenceCuotaService.java
@@ -53,7 +53,7 @@ public class PreferenceCuotaService {
         var tipoChequeraContext = getTipoChequeraContext(chequeraCuota.getTipoChequeraId(),
                 chequeraCuota.getAlternativaId());
         preferenceService.setAccessTokenAndLog();
-        PreferenceRequest preferenceRequest = preferenceService.buildPreferenceRequest(umPreferenceMPDto, tipoChequeraContext);
+        PreferenceRequest preferenceRequest = preferenceService.buildPreferenceRequest(umPreferenceMPDto, tipoChequeraContext, false);
         assert mercadoPagoContext != null;
         return preferenceService.createAndLogPreference(preferenceRequest, mercadoPagoContext);
     }
@@ -95,7 +95,7 @@ public class PreferenceCuotaService {
                 .email(payer.getEmail())
                 .build();
 
-        var paymentMethods = preferenceService.createPaymentMethodsRequest(tipoChequeraContext);
+        var paymentMethods = preferenceService.createPaymentMethodsRequest(tipoChequeraContext, false);
          log.debug("PaymentMethods -> {}", Jsonifier.builder(paymentMethods).build());
         // Crear un nuevo objeto PreferenceRequest con los valores actualizados
         PreferenceRequest updatedPreferenceRequest = PreferenceRequest.builder()

--- a/src/main/java/um/tesoreria/mercadopago/hexagonal/preference/service/PreferenceService.java
+++ b/src/main/java/um/tesoreria/mercadopago/hexagonal/preference/service/PreferenceService.java
@@ -38,7 +38,8 @@ public class PreferenceService {
     }
 
     public PreferenceRequest buildPreferenceRequest(UMPreferenceMPDto umPreferenceMPDto,
-                                                     TipoChequeraMercadoPagoCreditCardDto tipoChequeraContext) {
+                                                    TipoChequeraMercadoPagoCreditCardDto tipoChequeraContext,
+                                                    Boolean sinRestricciones) {
         log.debug("\n\nProcessing PreferenceCuotaService.buildPreferenceRequest\n\n");
         PreferenceItemRequest itemRequest = createItemRequest(umPreferenceMPDto);
         List<PreferenceItemRequest> itemRequests = List.of(itemRequest);
@@ -46,7 +47,7 @@ public class PreferenceService {
         PreferencePayerRequest payer = createPayerRequest(umPreferenceMPDto);
         String externalReference = createExternalReference(umPreferenceMPDto);
         PreferenceBackUrlsRequest backUrls = createBackUrlsRequest();
-        PreferencePaymentMethodsRequest paymentMethods = createPaymentMethodsRequest(tipoChequeraContext);
+        PreferencePaymentMethodsRequest paymentMethods = createPaymentMethodsRequest(tipoChequeraContext, sinRestricciones);
 
         var fechaVencimientoMP = DateToolMP
                 .convertToMPDate(umPreferenceMPDto.getMercadoPagoContext().getFechaVencimiento());
@@ -141,8 +142,15 @@ public class PreferenceService {
     }
 
     public PreferencePaymentMethodsRequest createPaymentMethodsRequest(
-            TipoChequeraMercadoPagoCreditCardDto tipoChequeraContext) {
+            TipoChequeraMercadoPagoCreditCardDto tipoChequeraContext, Boolean sinRestricciones) {
         log.debug("\n\nProcessing PreferenceService.createPaymentMethodsRequest\n\n");
+        if (Boolean.TRUE.equals(sinRestricciones)) {
+            return PreferencePaymentMethodsRequest.builder()
+                    .excludedPaymentTypes(List.of())
+                    .installments(null)
+                    .defaultInstallments(null)
+                    .build();
+        }
         List<PreferencePaymentTypeRequest> excludedPaymentTypes = new ArrayList<>(List.of(
                 PreferencePaymentTypeRequest.builder().id("ticket").build(),
                 PreferencePaymentTypeRequest.builder().id("prepaid_card").build()));

--- a/src/main/java/um/tesoreria/mercadopago/hexagonal/preference/vacante/application/service/PreferenceVacanteService.java
+++ b/src/main/java/um/tesoreria/mercadopago/hexagonal/preference/vacante/application/service/PreferenceVacanteService.java
@@ -30,7 +30,7 @@ public class PreferenceVacanteService {
         }
         var reservaVacante = umPreferenceMPDto.getReservaVacante();
         preferenceService.setAccessTokenAndLog();
-        PreferenceRequest preferenceRequest = preferenceService.buildPreferenceRequest(umPreferenceMPDto, null);
+        PreferenceRequest preferenceRequest = preferenceService.buildPreferenceRequest(umPreferenceMPDto, null, true);
         assert mercadoPagoContext != null;
         return preferenceService.createAndLogPreference(preferenceRequest, mercadoPagoContext);
     }


### PR DESCRIPTION
Closes #113

## Descripción

Se agrega el nuevo parámetro `sinRestricciones` en `PreferenceService` para permitir la creación de preferencias de pago sin exclusiones de medios de pago. El flujo de vacantes utiliza `sinRestricciones=true`, mientras que el flujo de cuotas preserva su comportamiento actual con `sinRestricciones=false`.

## Cambios Realizados

- **feat(preference):** Nuevo parámetro booleano `sinRestricciones` en `buildPreferenceRequest()` y `createPaymentMethodsRequest()`. Cuando es `true`, se genera un `PreferencePaymentMethodsRequest` sin exclusiones (sin límite de cuotas, sin excluir `ticket` ni `prepaid_card`).
- **feat(vacante):** `PreferenceVacanteService` invoca `buildPreferenceRequest(dto, null, true)` para generar preferencias sin restricciones en el flujo de reserva de vacantes.
- **refactor(cuota):** `PreferenceCuotaService` actualizado para usar `sinRestricciones=false`, preservando el comportamiento existente.
- **docs:** Diagramas de secuencia actualizados (`flujo-creacion-preferencia.mmd` y `flujo-creacion-vacante.mmd`).
- **chore:** Version bump `0.7.1 → 0.8.0` en `pom.xml`, `README.md` y `CHANGELOG.md`.

## Verificación

- [ ] Build del proyecto con `mvn clean compile` sin errores.
- [ ] Pruebas de creación de preferencia en flujo de cuotas (debe mantener exclusiones de `ticket` y `prepaid_card`).
- [ ] Pruebas de creación de preferencia en flujo de vacantes (debe permitir todos los medios de pago).
